### PR TITLE
A-Assertions: use and enable assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,4 +58,5 @@ shadowJar {
 
 run {
     standardInput = System.in
+    enableAssertions = true
 }

--- a/src/main/java/duke/utilities/Ui.java
+++ b/src/main/java/duke/utilities/Ui.java
@@ -49,6 +49,8 @@ public class Ui {
      * @return A string indicating the number of tasks in the task list.
      */
     public String formatNumberOfTasksAsString(int numTasks) {
+        assert numTasks >= 0;
+
         if (numTasks == 1) {
             return "There is 1 task in the list";
         } else {


### PR DESCRIPTION
Assert that the `formatNumberOfTasksAsString` function only receives non-negative integer arguments